### PR TITLE
docs: link every model README to the light-curve package (#28)

### DIFF
--- a/models/astra-clr/README.md
+++ b/models/astra-clr/README.md
@@ -1,5 +1,9 @@
 # AstraCLR
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 ## Paper
 
 Majumder et al., 2026, in prep.

--- a/models/astrom3/README.md
+++ b/models/astrom3/README.md
@@ -11,6 +11,10 @@ license: cc-by-4.0
 
 # AstroM3 (photo encoder)
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 **HuggingFace:** [light-curve/astrom3](https://huggingface.co/light-curve/astrom3)
 
 ## Paper

--- a/models/astromer1-ztfdr20/README.md
+++ b/models/astromer1-ztfdr20/README.md
@@ -10,6 +10,10 @@ library_name: onnx
 
 # Astromer 1 (ZTF DR20 g-band)
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 **HuggingFace:** [light-curve/astromer1-ztfdr20](https://huggingface.co/light-curve/astromer1-ztfdr20)
 
 ## Paper

--- a/models/astromer1/README.md
+++ b/models/astromer1/README.md
@@ -10,6 +10,10 @@ library_name: onnx
 
 # Astromer 1
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 **HuggingFace:** [light-curve/astromer1](https://huggingface.co/light-curve/astromer1)
 
 ## Paper

--- a/models/astromer2/README.md
+++ b/models/astromer2/README.md
@@ -10,6 +10,10 @@ library_name: onnx
 
 # Astromer 2
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 **HuggingFace:** [light-curve/astromer2](https://huggingface.co/light-curve/astromer2)
 
 ## Paper

--- a/models/atat/README.md
+++ b/models/atat/README.md
@@ -9,6 +9,10 @@ library_name: onnx
 
 # ATAT
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 ## Paper
 
 Becker, I., Pignata, G., Förster, F., Estévez, P. A., Cabrera-Vives, G., Vera, E., Carrasco-Davis, R., Astorga, N., Sanchez-Saez, P., Catelan, M., Cortés, C. C., de Jaeger, T., Pezoa, F., & Reyes, I. (2024). *ATAT: Astronomical Transformer for time series And Tabular data*. Astronomy & Astrophysics, 691, A163.

--- a/models/atcat/README.md
+++ b/models/atcat/README.md
@@ -9,6 +9,10 @@ library_name: onnx
 
 # ATCAT
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 **HuggingFace:** [light-curve/atcat](https://huggingface.co/light-curve/atcat)
 
 ## Paper

--- a/models/chronos2/README.md
+++ b/models/chronos2/README.md
@@ -1,5 +1,9 @@
 # Chronos 2
 
+> Part of the **[light-curve](https://github.com/light-curve)** family of open-source tools for astronomical time-series analysis.
+> Available from Python via the [`light-curve`](https://light-curve.snad.space/) package — `pip install light-curve`.
+> Documentation: <https://light-curve.snad.space/>
+
 ## Paper
 
 Ansari et al., 2025. "Chronos-2: Learning the Language of Time Series." Amazon Web Services.


### PR DESCRIPTION
Add a short banner near the top of each Hugging Face model card noting it is part of the light-curve family, with links to the GitHub org (https://github.com/light-curve), the Python docs
(https://light-curve.snad.space/), and the `pip install light-curve` install.